### PR TITLE
Changes naming strategy for enum values

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/MemberInfoExtensions.cs
@@ -47,14 +47,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             var displayAttribute = element.GetCustomAttribute<DisplayAttribute>(inherit: false);
             var enumMemberAttribute = element.GetCustomAttribute<EnumMemberAttribute>(inherit: false);
 
-            // EnumMemberAttribute takes precedence to DisplayAttribute
-            var name = !enumMemberAttribute.IsNullOrDefault()
-                       ? enumMemberAttribute.Value
-                       : (!displayAttribute.IsNullOrDefault()
-                          ? displayAttribute.Name
-                          : element.Name);
-
-            return namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+            return displayAttribute?.Name
+                ?? enumMemberAttribute?.Name
+                ?? name;
         }
     }
 }


### PR DESCRIPTION
Returns (in precedented order) display attribute, enum member attribute or the enum value itself, without applying a naming strategy (which is how enums have been returned in an asp.net openapi context).